### PR TITLE
Update rubocop version to the most recent supported by Hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -2,4 +2,4 @@ fail_on_violations: true
 
 rubocop:
   config_file: .ruby.yml
-  version: 0.73.0
+  version: 0.72.0


### PR DESCRIPTION
From HoundCI support: in .hound.yml  you're providing a 0.73.0 version, which we don't support yet