### PR TITLE
Change ExtraSpacing rule and sort alphabetically

### DIFF
--- a/0.79-v2.yml
+++ b/0.79-v2.yml
@@ -1,0 +1,151 @@
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/CaseIndentation:
+  EnforcedStyle: end
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Layout/EmptyLinesAroundBlockBody:
+  Exclude:
+    - '**/*_spec.rb'
+    - 'db/*.rb'
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
+
+Layout/ExtraSpacing:
+  AllowForAlignment: false
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/HashAlignment:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 160
+
+Layout/MultilineMethodCallBraceLayout:
+  Exclude:
+    - '**/*_spec.rb'
+
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+  Exclude:
+    - '**/*_spec.rb'
+
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    # so we can write expect { action }.not_to change { obj }
+    - '**/*_spec.rb'
+
+Lint/SuppressedException:
+  AllowComments: true
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 50
+
+Metrics/BlockLength:
+  Max: 30
+  Exclude:
+    - '**/spec/factories/**/*.rb'
+    - '**/*_spec.rb'
+    - 'db/**/*.rb'
+    - 'config/**/*.rb'
+    - 'spec/spec_helper.rb'
+
+Metrics/ClassLength:
+  Max: 300
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/MethodLength:
+  Max: 30
+  Exclude:
+    - 'db/**/*.rb'
+
+Metrics/ParameterLists:
+  Max: 8
+
+Metrics/PerceivedComplexity:
+  Max: 10
+
+Naming/AccessorMethodName:
+  Enabled: false
+
+Naming/PredicateName:
+  Exclude:
+    - '**/application_record.rb'
+
+Style/Alias:
+  # prefers alias_method over alias
+  EnforcedStyle: prefer_alias_method
+
+Style/BlockDelimiters:
+  Exclude:
+    - '**/*_spec.rb'
+
+Style/Documentation:
+  Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/Lambda:
+  Enabled: false
+
+Style/MixinUsage:
+  Exclude:
+    - 'bin/*'
+
+Style/NumericLiterals:
+  Exclude:
+    - 'db/*.rb'
+
+Style/NumericPredicate:
+  EnforcedStyle: comparison
+
+Style/PercentLiteralDelimiters:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
+Style/RescueStandardError:
+  Exclude:
+    - 'spec/**/*.rb'
+
+Style/SignalException:
+  EnforcedStyle: semantic
+
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_english_names
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/WordArray:
+  Exclude:
+    - 'db/**/*.rb'

--- a/rspec.yml
+++ b/rspec.yml
@@ -1,3 +1,11 @@
+RSpec/ContextWording:
+  Prefixes:
+    - when
+    - with
+    - without
+    - as
+    - given
+
 RSpec/DescribeClass:
   Enabled: false
 
@@ -21,11 +29,3 @@ RSpec/NamedSubject:
 
 RSpec/NestedGroups:
   Max: 4
-
-RSpec/ContextWording:
-  Prefixes:
-    - when
-    - with
-    - without
-    - as
-    - given


### PR DESCRIPTION
```ruby
#bad 
attribute :foo,       "bar"
attribute :foofoo,    "bar"
attribute :foofoofoo, "bar"


# good
attribute :foo, "bar"
attribute :foofoo, "bar"
attribute :foofoofoo, "bar"
```

The diff is unreadable, since I created a new file, so we don't make all the build suddenly failing.