### PR TITLE
Disable RSpec/MultipleMemoizedHelpers

### DIFF
--- a/rspec.yml
+++ b/rspec.yml
@@ -26,6 +26,9 @@ RSpec/MessageSpies:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 RSpec/NamedSubject:
   Enabled: false
 


### PR DESCRIPTION
## Description

When you need more helpers, you need more helpers. You should not need
to disable the cop for every other spec file or cheat by using hardcoded
values.

## Related PRs

https://github.com/RenoFi/renometry/pull/15/files
