### PR TITLE
Allow shorter param names

### DIFF
--- a/ruby.yml
+++ b/ruby.yml
@@ -102,6 +102,12 @@ Naming/PredicateName:
 Naming/VariableNumber:
   Enabled: false
 
+Naming/MethodParameterName:
+  Enabled: true
+  MinNameLength: 2
+  AllowedNames:
+    - _
+
 Style/Alias:
   # prefers alias_method over alias
   EnforcedStyle: prefer_alias_method


### PR DESCRIPTION
## Description

Some short param names just make sense: `at`, `as`, `on`, `to`, etc.

## Related PRs

https://github.com/RenoFi/renometry/pull/57
