### PR TITLE
bring back Layout/EmptyLineAfterGuardClause - it is actually a good r…

### DIFF
--- a/ruby.yml
+++ b/ruby.yml
@@ -7,9 +7,6 @@ Layout/ArgumentAlignment:
 Layout/CaseIndentation:
   EnforcedStyle: end
 
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-
 Layout/EmptyLinesAroundBlockBody:
   Exclude:
     - '**/*_spec.rb'


### PR DESCRIPTION
## Description, motivation and context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->


bring back `Layout/EmptyLineAfterGuardClause` 
- it is actually a good rule. It makes it super easy to spot any `return` (which stops the flow).

