### PR TITLE
disable Style/MapToHash

### DIFF
--- a/ruby.yml
+++ b/ruby.yml
@@ -178,3 +178,6 @@ Style/TrailingCommaInArguments:
 Style/WordArray:
   Exclude:
     - 'db/**/*.rb'
+
+Style/MapToHash:
+  Enabled: false


### PR DESCRIPTION
## Description, motivation and context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

`Style/MapToHash` rule disabled.

it makes sense on `Enumerable`, but not on any possible object. 
i.e. in [Renoforce](https://github.com/RenoFi/renoforce/blob/43e6a5198ca947cf352ee876de89d8dd37b26294/lib/factories/postcard_lead_scenario.rb#L57) we have classes which have `.map` method defined but it is not necesairly an Enumerable (so i.e. does not have `to_h` defined)