### PR TITLE
Allow federation method in block length

### DIFF
--- a/ruby.yml
+++ b/ruby.yml
@@ -60,6 +60,8 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
   Max: 30
+  AllowedMethods:
+    - with_federation_enabled
   Exclude:
     - '*.gemspec'
     - 'db/**/*.rb'


### PR DESCRIPTION
## Description, motivation and context
So we don't need to disable this cop on every federation block

```
graphql/types/feasibility_review_type.rb:9:42: W: [Corrected] Lint/RedundantCopDisableDirective: Unnecessary disabling of Metrics/BlockLength.
    with_federation_enabled do |enabled| # rubocop:disable Metrics/BlockLength
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Related issue(s) or PR(s)
1. https://github.com/RenoFi/renovation/pull/2246
2. https://github.com/RenoFi/contractor/pull/819
3. https://github.com/RenoFi/lender/pull/517