### PR TITLE
Disable RSpec/IndexedLet

### DIFF
--- a/rspec.yml
+++ b/rspec.yml
@@ -50,3 +50,6 @@ RSpec/ReturnFromStub:
 
 RSpec/StubbedMock:
   Enabled: false
+
+RSpec/IndexedLet:
+  Enabled: false


### PR DESCRIPTION
## Description, motivation and context

It's just plain stupid.