### PR TITLE
`RSpec/IndexedLet` removed (not supported in the newest rubocop)

### DIFF
--- a/rspec.yml
+++ b/rspec.yml
@@ -50,6 +50,3 @@ RSpec/ReturnFromStub:
 
 RSpec/StubbedMock:
   Enabled: false
-
-RSpec/IndexedLet:
-  Enabled: false


### PR DESCRIPTION
## Description, motivation and context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

`RSpec/IndexedLet` removed (not supported in the newest rubocop)

```
Running RuboCop...00:13
Error: unrecognized cop or department RSpec/IndexedLet found in .rubocop-https---raw-githubusercontent-com-RenoFi-rubocop-main-rspec-yml00:13
Did you mean `RSpec/Yield`?
```


## Related issue(s) or PR(s)
<!--- GH issue number -->

https://renofi.semaphoreci.com/jobs/f6bff6ae-455e-4abd-b358-b5fc73478618