### PR TITLE
Lint/DuplicateBranch - ignore literal and const branches

### DIFF
--- a/ruby.yml
+++ b/ruby.yml
@@ -30,6 +30,10 @@ Layout/FirstArrayElementIndentation:
 Layout/HashAlignment:
   Enabled: false
 
+Lint/DuplicateBranch:
+  IgnoreLiteralBranches: true,
+  IgnoreConstantBranches: true
+
 Layout/LineLength:
   Max: 160
   Exclude:


### PR DESCRIPTION
## Description, motivation and context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

```
Lint/DuplicateBranch
  IgnoreLiteralBranches: true,
  IgnoreConstantBranches: true
```

## Related issue(s) or PR(s)
<!--- GH issue number -->

example:
```ruby
  case some_attr
  when :something, :blah, :foo
    123
  when :something_else, :bar
    234
  else # any value we are not aware of, which might appear in future
    123
  end
```
